### PR TITLE
[6]empty fields on global screen

### DIFF
--- a/app/src/main/java/com/example/ncov19traking/MainActivity.kt
+++ b/app/src/main/java/com/example/ncov19traking/MainActivity.kt
@@ -16,6 +16,7 @@ class MainActivity : AppCompatActivity() {
         setContentView(R.layout.activity_main)
         val navView: BottomNavigationView = findViewById(R.id.nav_view)
         val navController = findNavController(R.id.nav_host_fragment)
+        navView.setOnNavigationItemReselectedListener { }
         // Passing each menu ID as a set of Ids because each
         // menu should be considered as top level destinations.
         val appBarConfiguration = AppBarConfiguration(setOf(

--- a/app/src/main/java/com/example/ncov19traking/ui/countries/CountriesFragment.kt
+++ b/app/src/main/java/com/example/ncov19traking/ui/countries/CountriesFragment.kt
@@ -6,7 +6,7 @@ import android.widget.ProgressBar
 import android.widget.Toast
 import androidx.appcompat.widget.SearchView
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -17,7 +17,7 @@ import com.example.ncov19traking.models.ErrorBody
 
 class CountriesFragment : Fragment() {
 
-    private val countriesViewModel by viewModels<CountriesViewModel>()
+    private val countriesViewModel by activityViewModels<CountriesViewModel>()
     private val nCoVRecyclerAdapter = NCoVRecyclerAdapter()
     private var isSortedByCases = true
 

--- a/app/src/main/java/com/example/ncov19traking/ui/global/GlobalFragment.kt
+++ b/app/src/main/java/com/example/ncov19traking/ui/global/GlobalFragment.kt
@@ -6,7 +6,7 @@ import android.widget.ProgressBar
 import android.widget.TextView
 import android.widget.Toast
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Observer
 import com.example.ncov19traking.AlertDialogBuilder
 import com.example.ncov19traking.R
@@ -15,7 +15,7 @@ import java.util.*
 
 class GlobalFragment : Fragment() {
 
-    private val homeViewModel by viewModels<GlobalViewModel>()
+    private val homeViewModel by activityViewModels<GlobalViewModel>()
     private lateinit var progressBar: ProgressBar
 
     override fun onCreateView(

--- a/app/src/main/java/com/example/ncov19traking/ui/graphs/GraphsFragment.kt
+++ b/app/src/main/java/com/example/ncov19traking/ui/graphs/GraphsFragment.kt
@@ -8,7 +8,7 @@ import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Observer
 import com.example.ncov19traking.R
 import com.example.ncov19traking.models.ErrorBody
@@ -21,7 +21,7 @@ import com.github.mikephil.charting.interfaces.datasets.ILineDataSet
 
 class GraphsFragment : Fragment() {
 
-    private val graphsViewModel by viewModels<GraphsViewModel>()
+    private val graphsViewModel by activityViewModels<GraphsViewModel>()
 
     override fun onCreateView(
             inflater: LayoutInflater,


### PR DESCRIPTION
# Description

fixed issue causing empty fields on global screen for moments on returning from another fragment #6 

also fixed issue from ticket #7 causing to reload fragment on reselected item

# ChangeType

issue solving, not breaking bugfixes 

# Steps to test

Open the app -> use bottomnav to change between fragments -> return to a fragment already open.

also for #7 , reselect item of the fragment you are currently at.

